### PR TITLE
chore: update docker setup for deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,22 @@
-# Dockerfile para projeto Node.js/TypeScript (Vite)
+## Dockerfile para build e execução em produção
 FROM node:20-alpine
 
-# Diretório de trabalho
 WORKDIR /app
 
-# Copia os arquivos de dependências
+# Copia os arquivos de dependências e instala
 COPY package.json package-lock.json* bun.lockb* ./
+RUN npm install
 
-# Instala as dependências
-RUN npm install || bun install
-
-# Copia o restante do código
+# Copia o restante do código-fonte
 COPY . .
 
-# Expõe a porta padrão do Vite
-EXPOSE 5173
+# Build do front-end e do servidor
+RUN npm run build && npm run build:server
 
-# Comando padrão para desenvolvimento
-CMD ["npm", "run", "dev"]
+ENV NODE_ENV=production
+
+# Expõe a porta da API
+EXPOSE 3001
+
+# Comando para iniciar o servidor compilado
+CMD ["npm", "run", "start:server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,14 +4,17 @@ services:
     build: .
     container_name: neuro-boost-app
     ports:
-      - '5173:5173' # Vite default port
-    volumes:
-      - .:/app
+      - '3001:3001'
     environment:
-      - NODE_ENV=development
+      NODE_ENV: production
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_NAME: neuroboost
+      DB_USER: neuroboost
+      DB_PASSWORD: neuroboostpass
     depends_on:
       - db
-    command: sh -c "npm install && npm run dev"
+    restart: always
 
   db:
     image: postgres:15


### PR DESCRIPTION
## Summary
- build frontend and server during image build
- run compiled server on port 3001
- configure docker-compose with database env vars for production

## Testing
- `npm test -- --run` *(fails: FocusService tests cannot access database, break_suggestion not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bb80f160832dba735b3941d1e545